### PR TITLE
✨ feat: add support for Gitmojis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "cz-emoji-conventional",
-  "version": "1.0.2",
+  "name": "@r1d3r175/cz-emoji-conventional",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "cz-emoji-conventional",
-  "version": "1.1.0",
+  "name": "@r1d3r175/cz-emoji-conventional",
+  "version": "1.2.0",
   "description": "commitizen adapter for conventional commit messages with emoji",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@r1d3r175/cz-emoji-conventional",
+  "name": "cz-emoji-conventional",
   "version": "1.2.0",
   "description": "commitizen adapter for conventional commit messages with emoji",
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,22 @@ In order to use, install `commitizen` and `cz-emoji-conventional`. Then, just ad
   },
 ```
 
+### Using with `commitlint`
+If you wish to use this adapter with `commitlint`, use `commitlint-config-gitmoji` as  configuration
+```
+npm install -D commitlint-config-gitmoji
+```
+Then set `useGitmojis` to `true` in the `commitizen` config 
+```json
+  "config": {
+    "commitizen": {
+      "path": "node_modules/cz-emoji-conventional",
+      "useGitmojis": true
+    }
+  },
+```
+
+
 ## Configuration
 
 Configuration options of [cz-conventional-changelog](https://github.com/commitizen/cz-conventional-changelog) can be used.

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,3 +1,17 @@
+export const gitmojiByType: { [key: string]: string } = {
+  feat: "✨",
+  fix: "🐛",
+  docs: "📝",
+  style: "💄",
+  refactor: "♻️",
+  perf: "⚡️",
+  test: "✅",
+  build: "🏗️",
+  ci: "👷",
+  chore: "🔧",
+  revert: "⏪️"
+};
+
 export const types = {
   feat: {
     description: "A new feature",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { green, red } from "chalk";
 import { configLoader } from "commitizen";
 import wrap from "word-wrap";
 
-import { types } from "./constant";
+import { gitmojiByType, types } from "./constant";
 
 const config = configLoader.load() || {};
 
@@ -79,15 +79,19 @@ export const prompter = (
 ) => {
   const typeList = Object.keys(options.types);
   const length = typeList.reduce((a, c) => Math.max(a, c.length), 0) + 2;
-  const choices = typeList.map((t) => ({
-    name:
-      options.types[t].emoji +
-      " " +
-      (t + ":").padEnd(length) +
-      " " +
-      options.types[t].description,
-    value: options.types[t].emoji + " " + t,
-  }));
+  const choices = typeList.map((t) => {
+    const emoji = config?.useGitmojis ? gitmojiByType[t] : options.types[t].emoji;
+
+    return {
+      name:
+        emoji +
+        " " +
+        (t + ":").padEnd(length) +
+        " " +
+        options.types[t].description,
+      value: emoji + " " + t,
+    }
+  });
 
   cz.prompt([
     {


### PR DESCRIPTION
## Why?
When using this adapter with `commitlint` configured with `commitlint-config-gitmoji` linting will fail all the time since some emojis aren't in the emoji convention.
By adding support to Gitmoji's emoji, an emoji configuration of `commitlint` and `commitized` becomes very trivial to achieve.

## What does this PR do?
This PR adds a *non-breaking* feature that switches the emoji used based on a property named `useGitmojis` in the `commitizen` config.